### PR TITLE
Feat filter posts

### DIFF
--- a/public/stylesheets/css/bundle.css
+++ b/public/stylesheets/css/bundle.css
@@ -101,6 +101,10 @@ main {
       position: absolute;
       top: 50%;
       width: 45px; }
+      .header-logo__icon-anchor {
+        display: block;
+        height: 100%;
+        width: 100%; }
 
 @media only screen and (min-width: 1170px) {
   .header-wrapper {

--- a/public/stylesheets/css/bundle.css
+++ b/public/stylesheets/css/bundle.css
@@ -47,6 +47,19 @@ table {
   -webkit-line-clamp: 8;
   -webkit-box-orient: vertical; }
 
+a.anchor-null:link {
+  color: inherit;
+  text-decoration: none; }
+a.anchor-null:visited {
+  color: inherit;
+  text-decoration: none; }
+a.anchor-null:hover {
+  color: inherit;
+  text-decoration: none; }
+a.anchor-null:active {
+  color: inherit;
+  text-decoration: none; }
+
 html {
   font-family: "Open Sans", sans-serif;
   font-size: 12px; }

--- a/public/stylesheets/sass/app/_header.sass
+++ b/public/stylesheets/sass/app/_header.sass
@@ -41,6 +41,11 @@ $logo-height: 45px
             top: 50%
             width: $logo-height
 
+            &-anchor
+                display: block
+                height: 100%
+                width: 100%
+
 // Desktop screens
 @media only screen and (min-width: 1170px)
     .header

--- a/public/stylesheets/sass/utils/_objects.sass
+++ b/public/stylesheets/sass/utils/_objects.sass
@@ -2,3 +2,20 @@
     display: -webkit-box
     -webkit-line-clamp: 8
     -webkit-box-orient: vertical
+
+a.anchor-null
+    &:link
+        color: inherit
+        text-decoration: none
+
+    &:visited
+        color: inherit
+        text-decoration: none
+
+    &:hover
+        color: inherit
+        text-decoration: none
+
+    &:active
+        color: inherit
+        text-decoration: none

--- a/src/components/CklApp.js
+++ b/src/components/CklApp.js
@@ -1,20 +1,15 @@
 import React from 'react'
 import { Provider } from 'react-redux'
 
-import configureStore from '../store'
-
 import Header from './Header'
 import PostList from './PostList'
 
-const store = configureStore()
 
 const CklApp = () => (
-    <Provider store={store}>
-        <div>
-            <Header />
-            <PostList />
-        </div>
-    </Provider>
+    <div>
+        <Header />
+        <PostList />
+    </div>
 )
 
 

--- a/src/components/CklApp.js
+++ b/src/components/CklApp.js
@@ -1,13 +1,13 @@
 import React from 'react'
 
 import Header from './Header'
-import PostList from './PostList'
+import PostListVisible from './PostListVisible'
 
 
 const CklApp = () => (
     <div>
         <Header />
-        <PostList />
+        <PostListVisible />
     </div>
 )
 

--- a/src/components/CklApp.js
+++ b/src/components/CklApp.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Provider } from 'react-redux'
 
 import Header from './Header'
 import PostList from './PostList'

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -44,13 +44,9 @@ let Header = ({
     </header>
 )
 
-const mapStateToProps = (state) => {
-    const menu = state.menu
-
-    return {
-        menu,
-    }
-}
+const mapStateToProps = (state) => ({
+    menu: state.menu
+})
 
 Header = connect(
     mapStateToProps,

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -21,7 +21,7 @@ let Header = ({
 
             <div className='header-logo'>
                 <div className='header-logo__icon'>
-                    <Link to='all'
+                    <Link to='/'
                           className='anchor-null header-logo__icon-anchor'>
                           C
                     </Link>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,9 +2,9 @@ import React from 'react'
 import { connect } from 'react-redux'
 
 import classNames from 'classnames'
-
 import { toggleMenu } from '../actions'
 
+import HeaderItem from './HeaderItem'
 
 let Header = ({
     toggleMenu,
@@ -24,21 +24,11 @@ let Header = ({
             </div>
             
             <nav className={classNames('header-items', !menu && 'header-items-hide')}>
-                <div className='header-item'>
-                    POLITICS
-                </div>
-                <div className='header-item'>
-                    BUSINESS
-                </div>
-                <div className='header-item'>
-                    TECH
-                </div>
-                <div className='header-item'>
-                    SCIENCE
-                </div>
-                <div className='header-item'>
-                    SPORTS
-                </div>
+                <HeaderItem tag='politics' />
+                <HeaderItem tag='business' />
+                <HeaderItem tag='tech' />
+                <HeaderItem tag='science' />
+                <HeaderItem tag='sports' />
             </nav>
         </div>
     </header>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,10 +1,12 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import { Link } from 'react-router'
 
 import classNames from 'classnames'
 import { toggleMenu } from '../actions'
 
 import HeaderItem from './HeaderItem'
+
 
 let Header = ({
     toggleMenu,
@@ -19,7 +21,10 @@ let Header = ({
 
             <div className='header-logo'>
                 <div className='header-logo__icon'>
-                    C
+                    <Link to='all'
+                          className='anchor-null header-logo__icon-anchor'>
+                          C
+                    </Link>
                 </div>
             </div>
             

--- a/src/components/HeaderItem.js
+++ b/src/components/HeaderItem.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Link } from 'react-router'
+
+
+const HeaderItem = ({ tag }) => (
+    <div className='header-item'>
+        <Link to={tag}>{tag.toUpperCase()}</Link>
+    </div>
+)
+
+
+export default HeaderItem

--- a/src/components/HeaderItem.js
+++ b/src/components/HeaderItem.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router'
 
 const HeaderItem = ({ tag }) => (
     <div className='header-item'>
-        <Link to={tag}>{tag.toUpperCase()}</Link>
+        <Link to={tag} className='anchor-null'>{tag.toUpperCase()}</Link>
     </div>
 )
 

--- a/src/components/PostList.js
+++ b/src/components/PostList.js
@@ -1,9 +1,7 @@
 import React from 'react'
 
-import DB from '../db'
-import { separatePosts } from '../libs/post_lib'
-
 import Post from './Post'
+
 
 const renderPost = (post) => (
     <Post
@@ -17,14 +15,17 @@ const renderPost = (post) => (
     />
 )
 
-const PostList = () => (
+const PostList = ({
+    main_posts,
+    second_posts,
+}) => (
     <main>
         <section className='posts-top'>
-            {separatePosts(DB).main_posts.map((p, index) => renderPost(p))}
+            {main_posts.map((p, index) => renderPost(p))}
         </section>
 
         <section className='posts-bottom'>
-            {separatePosts(DB).second_posts.map((p, index) => renderPost(p))}
+            {second_posts.map((p, index) => renderPost(p))}
         </section>
     </main>
 )

--- a/src/components/PostListVisible.js
+++ b/src/components/PostListVisible.js
@@ -1,5 +1,5 @@
-import React, { Component } from 'react'
 import { connect } from 'react-redux'
+import { withRouter } from 'react-router'
 
 import { separatePosts } from '../libs/post_lib'
 import db from '../db'
@@ -7,24 +7,18 @@ import db from '../db'
 import PostList from './PostList'
 
 
-class PostListVisible extends Component {
-    render () {
-        return (
-            <PostList
-                {...this.props}
-            />
-        )
+const mapStateToProps = (state, { params }) => {
+    const visible_posts = db.filter((post) => post.tag.toLowerCase() === params.filter.toLowerCase())
+
+    return {
+        ...separatePosts(visible_posts),
     }
 }
 
-const mapStateToProps = () => ({
-    ...separatePosts(db)
-})
-
-PostListVisible = connect(
+const PostListVisible = withRouter(connect(
     mapStateToProps,
     null,
-)(PostListVisible)
+)(PostList))
 
 
 export default PostListVisible

--- a/src/components/PostListVisible.js
+++ b/src/components/PostListVisible.js
@@ -1,19 +1,15 @@
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 
-import { separatePosts } from '../libs/post_lib'
+import { filterPosts, separatePosts } from '../libs/post_lib'
 import db from '../db'
 
 import PostList from './PostList'
 
 
-const mapStateToProps = (state, { params }) => {
-    const visible_posts = db.filter((post) => post.tag.toLowerCase() === params.filter.toLowerCase())
-
-    return {
-        ...separatePosts(visible_posts),
-    }
-}
+const mapStateToProps = (state, { params }) => ({
+    ...separatePosts(filterPosts(db, params.filter)),
+})
 
 const PostListVisible = withRouter(connect(
     mapStateToProps,

--- a/src/components/PostListVisible.js
+++ b/src/components/PostListVisible.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+
+import { separatePosts } from '../libs/post_lib'
+import db from '../db'
+
+import PostList from './PostList'
+
+
+class PostListVisible extends Component {
+    render () {
+        return (
+            <PostList
+                {...this.props}
+            />
+        )
+    }
+}
+
+const mapStateToProps = () => ({
+    ...separatePosts(db)
+})
+
+PostListVisible = connect(
+    mapStateToProps,
+    null,
+)(PostListVisible)
+
+
+export default PostListVisible

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Provider } from 'react-redux'
+import { Router, Route, browserHistory } from 'react-router'
+
+import CklApp from './CklApp'
+
+
+const Root = ({ store }) => (
+    <Provider store={store}>
+        <Router history={browserHistory}>
+            <Route path='/(:filter)' component={CklApp}/>
+        </Router>
+    </Provider>
+)
+
+
+export default Root

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,14 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-import CklApp from './components/CklApp'
+import configureStore from './store'
 
+import Root from './components/Root'
+
+
+const store = configureStore()
 
 ReactDOM.render(
-    <CklApp />,
+    <Root store={store} />,
     document.getElementById('root')
 )

--- a/src/libs/post_lib.js
+++ b/src/libs/post_lib.js
@@ -1,8 +1,9 @@
 // separatePosts returns two array of posts: { main_posts, second_posts }
 // so we can show them in different sections of the page
-export const separatePosts = (posts, index = 3) => {
-    return {
-        main_posts: posts.slice(0, index),
-        second_posts: posts.slice(index, posts.length),
-    }
-}
+export const separatePosts = (posts, index = 3) => ({
+    main_posts: posts.slice(0, index),
+    second_posts: posts.slice(index, posts.length),
+})
+
+export const filterPosts = (posts, filter) =>
+    filter ? posts.filter(p => p.tag.toLowerCase() === filter) : posts


### PR DESCRIPTION
This feature enables the user to click at one of the header menu items and filter the list of posts by tag.

If the user clicks the app logo (on the header bar), the filter is set to 'all posts'.

The filters are based on the address bar (a.k.a. app routes).